### PR TITLE
Silently create Wineprefix

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -53,6 +53,7 @@ finish-args:
   - --device=all
   # Support 32-bit runtime
   - --env=LD_LIBRARY_PATH=/app/lib:/app/lib32
+  - --env=WINEDLLOVERRIDES=mscoree,mshtml=
   - --allow=multiarch
 
 modules:

--- a/fightcade-launcher.sh
+++ b/fightcade-launcher.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
+# Silently create/update Wine prefix
+WINEDEBUG=-all DISPLAY=:invalid wineboot -u
+
+# Boot Fightcade frontend
 /app/bin/zypak-wrapper /app/extra/Fightcade/fc2-electron/fc2-electron


### PR DESCRIPTION
Remove Gecko & Mono popups by setting WINEDLLOVERRIDES=mscoree,mshtml

Use `wineboot -u` to silently update the wineprefix at start (in
fightcade-launcher.sh)

Resolves https://github.com/Pobega/com.fightcade.Fightcade/issues/10