### PR TITLE
Handle fcade:// URIs

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -54,6 +54,7 @@ finish-args:
   - --device=all
   # Persist Wineprefix as ~/.var/app/{fightcade}/.wine
   - --persist=.wine
+  - --persist=logs
   # Skip Gecko and Mono popups when creating Wine prefix
   - --env=WINEDLLOVERRIDES=mscoree,mshtml=
   # Support 32-bit runtime
@@ -91,6 +92,17 @@ modules:
           - tar -xf fightcade.tar.gz
           # Temporary workaround to get FBNeo to have a default config.
           - cp Fightcade/emulator/fbneo/config/fcadefbneo.default.ini Fightcade/emulator/fbneo/config/fcadefbneo.ini
+          # Log file Fightcade expects to be able to write to
+          - touch ~/logs/fcade-errors.log
+          - ln -s ~/logs/fcade-errors.log Fightcade/emulator/fcade-errors.log
+          - touch ~/logs/fcade.log
+          - ln -s ~/logs/fcade.log Fightcade/emulator/fcade.log
+          - touch ~/logs/fcade.log.1
+          - ln -s ~/logs/fcade.log.1 Fightcade/emulator/fcade.log.1
+          - touch ~/logs/fcade.log.2
+          - ln -s ~/logs/fcade.log.2 Fightcade/emulator/fcade.log.3
+          - touch ~/logs/fcade.log.3
+          - ln -s ~/logs/fcade.log.3 Fightcade/emulator/fcade.log.2
           - rm -f fightcade.tar.gz
       - type: file
         path: com.fightcade.Fightcade.desktop

--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -70,7 +70,9 @@ modules:
     buildsystem: simple
     build-commands:
       - install -Dm755 com.fightcade.Fightcade.desktop /app/share/applications/com.fightcade.Fightcade.desktop
+      - install -Dm755 fcade-quark.desktop /app/share/applications/com.fightcade.Fightcade.fcade-quark.desktop
       - install -Dm755 fightcade-launcher.sh /app/bin/fightcade
+      - install -Dm755 fcade-quark.sh /app/bin/fcade-quark
       - install -Dm755 com.fightcade.Fightcade-64.png /app/share/icons/hicolor/64x64/apps/com.fightcade.Fightcade.png
       - install -Dm755 com.fightcade.Fightcade-128.png /app/share/icons/hicolor/128x128/apps/com.fightcade.Fightcade.png
       - install -Dm755 com.fightcade.Fightcade-256.png /app/share/icons/hicolor/256x256/apps/com.fightcade.Fightcade.png
@@ -93,6 +95,8 @@ modules:
       - type: file
         path: com.fightcade.Fightcade.desktop
       - type: file
+        path: fcade-quark.desktop
+      - type: file
         path: icons/com.fightcade.Fightcade-64.png
       - type: file
         path: icons/com.fightcade.Fightcade-128.png
@@ -100,6 +104,8 @@ modules:
         path: icons/com.fightcade.Fightcade-256.png
       - type: file
         path: fightcade-launcher.sh
+      - type: file
+        path: fcade-quark.sh
       - type: file
         path: com.fightcade.Fightcade.appdata.xml
 

--- a/fcade-quark.desktop
+++ b/fcade-quark.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Encoding=UTF-8
+NoDisplay=true
+Name=FightCade Replay
+Exec=fcade-quark %U
+MimeType=x-scheme-handler/fcade
+Terminal=false
+X-Flatpak=com.fightcade.Fightcade

--- a/fcade-quark.sh
+++ b/fcade-quark.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+PARAM=${1+"$@"}
+
+export WINEDEBUG=-all
+
+/app/extra/Fightcade/emulator/fcade ${PARAM} 2>&1 &


### PR DESCRIPTION
Resolves #19 

Creates an wrapper for `emulators/fcade` that passes `fcade://` URIs through. 

Also adds some symlinks for logfiles and makes them persistent in a `logs/` directory (mapped to `~/.var/app/com.fightcade.Fightcade/logs`)