### PR TITLE
Symlink files on read-only /app to writable locations

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -52,9 +52,10 @@ finish-args:
   - --allow=multiarch
   - --talk-name=org.freedesktop.Notifications
   - --device=all
+  - --persist=ROMs
+  - --persist=config
   # Persist Wineprefix as ~/.var/app/{fightcade}/.wine
   - --persist=.wine
-  - --persist=logs
   # Skip Gecko and Mono popups when creating Wine prefix
   - --env=WINEDLLOVERRIDES=mscoree,mshtml=
   # Support 32-bit runtime

--- a/scripts/apply_extra
+++ b/scripts/apply_extra
@@ -1,23 +1,30 @@
 #!/bin/sh
 
+DATADIR=/var/data
+
 # Untar our Fightcade download
 tar -xf fightcade.tar.gz
 rm -f fightcade.tar.gz
 
-# Temporary workaround to get FBNeo to have a default config.
-cp Fightcade/emulator/fbneo/config/fcadefbneo.default.ini Fightcade/emulator/fbneo/config/fcadefbneo.ini
+ln -s ${DATADIR}/fc2json Fightcade/emulator/fc2json
+
+# Symlink the ROMs folder to persistent directories
+rmdir Fightcade/emulator/fbneo/ROMs
+ln -s ~/ROMs/fbneo Fightcade/emulator/fbneo/ROMs
+rmdir Fightcade/emulator/ggpofba/ROMs
+ln -s ~/ROMs/ggpofba Fightcade/emulator/ggpofba/ROMs
+rmdir Fightcade/emulator/snes9x/ROMs
+ln -s ~/ROMs/snes9x Fightcade/emulator/snes9x/ROMs
 
 # Log file Fightcade expects to be able to write to
-touch ~/logs/fcade-errors.log
-ln -s ~/logs/fcade-errors.log Fightcade/emulator/fcade-errors.log
-touch ~/logs/fcade.log
-ln -s ~/logs/fcade.log Fightcade/emulator/fcade.log
-touch ~/logs/fcade.log.1
-ln -s ~/logs/fcade.log.1 Fightcade/emulator/fcade.log.1
-touch ~/logs/fcade.log.2
-ln -s ~/logs/fcade.log.2 Fightcade/emulator/fcade.log.3
-touch ~/logs/fcade.log.3
-ln -s ~/logs/fcade.log.3 Fightcade/emulator/fcade.log.2
+ln -s ${DATADIR}/logs/fcade-errors.log Fightcade/emulator/fcade-errors.log
+ln -s ${DATADIR}/logs/fcade.log Fightcade/emulator/fcade.log
+ln -s ${DATADIR}/logs/fcade.log.1 Fightcade/emulator/fcade.log.1
+ln -s ${DATADIR}/logs/fcade.log.2 Fightcade/emulator/fcade.log.3
+ln -s ${DATADIR}/logs/fcade.log.3 Fightcade/emulator/fcade.log.2
+
+# Symlink FBNeo default config to writable file
+ln -s ~/config/fcadefbneo.ini Fightcade/emulator/fbneo/config/fcadefbneo.ini
 
 # Create a wine wrapper for Fightcade.
 # Fightcade is hardcoded to expect /usr/{local/,}bin/wine, but is

--- a/scripts/fightcade-launcher.sh
+++ b/scripts/fightcade-launcher.sh
@@ -1,7 +1,29 @@
 #!/bin/sh
 
+DATADIR=/var/data
+
 # Silently create/update Wine prefix
 WINEDEBUG=-all DISPLAY=:invalid wineboot -u
+
+# Create config files
+mkdir -p ${DATADIR}/fc2json
+
+# Log file Fightcade expects to be able to write to
+mkdir -p /var/data/logs
+touch ${DATADIR}/logs/fcade-errors.log
+touch ${DATADIR}/logs/fcade.log
+touch ${DATADIR}/logs/fcade.log.1
+touch ${DATADIR}/logs/fcade.log.2
+touch ${DATADIR}/logs/fcade.log.3
+
+# Create persistent ROM folders if they don't exist
+mkdir -p ~/ROMs/fbneo
+mkdir -p ~/ROMs/ggpofba
+mkdir -p ~/ROMs/snes9x
+
+# Emulator config directory
+mkdir -p ~/config
+cp -n /app/extra/Fightcade/emulator/fbneo/config/fcadefbneo.default.ini ~/config/fcadefbneo.ini
 
 # Boot Fightcade frontend
 /app/bin/zypak-wrapper /app/extra/Fightcade/fc2-electron/fc2-electron


### PR DESCRIPTION
Fightcade expects to be able to write to some paths relative to it's
location such as log files and emulator configs. This commit symlinks
the offending files to writable directories.

Resolves #28 